### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/base/views.py
+++ b/base/views.py
@@ -3,6 +3,9 @@ from django.shortcuts import redirect, render
 import requests
 import datetime
 from django.http import JsonResponse, HttpResponse
+import logging
+
+logger = logging.getLogger(__name__)
 
 def dragon_public(request):
     url = settings.DRAGON_PUBLIC_URL
@@ -41,7 +44,8 @@ def dragon_public(request):
 
     except requests.exceptions.RequestException as e:
         # Handle any request errors
-        return HttpResponse(f"Error fetching data: {e}", status=500)
+        logger.error(f"Error fetching data from {url}: {e}")
+        return HttpResponse("An internal error has occurred. Please try again later.", status=500)
     
 def redirect_to_texture(request):
     return redirect('follow_dragon_earthtexture')


### PR DESCRIPTION
Potential fix for [https://github.com/ridwaanhall/follow-dragon-spacex/security/code-scanning/2](https://github.com/ridwaanhall/follow-dragon-spacex/security/code-scanning/2)

To fix the problem, we need to ensure that detailed error information is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by using Django's logging framework to log the exception and returning a generic error message in the HTTP response.

1. Import the `logging` module.
2. Configure a logger for the module.
3. Log the detailed exception message using the logger.
4. Return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
