### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/base/views.py
+++ b/base/views.py
@@ -4,6 +4,9 @@ from django.views import View
 from django.http import JsonResponse, HttpResponse
 import requests
 import datetime
+import logging
+
+logging.basicConfig(level=logging.ERROR)
 
 class DragonPublicView(View):
     def get(self, request):
@@ -35,7 +38,8 @@ class DragonPublicView(View):
             json_data = response.json()
             return JsonResponse(json_data, safe=False)
         except requests.exceptions.RequestException as e:
-            return HttpResponse(f"Error fetching data: {e}", status=500)
+            logging.error(f"Error fetching data: {e}")
+            return HttpResponse("An internal error has occurred.", status=500)
 
 class EarthTextureView(View):
     def get(self, request):


### PR DESCRIPTION
Potential fix for [https://github.com/ridwaanhall/follow-dragon-spacex/security/code-scanning/3](https://github.com/ridwaanhall/follow-dragon-spacex/security/code-scanning/3)

To fix the problem, we need to ensure that detailed error messages are not exposed to the end user. Instead, we should log the detailed error message on the server side and return a generic error message to the user. This can be achieved by using Python's logging module to log the exception details and returning a generic error message in the HTTP response.

1. Import the `logging` module.
2. Configure the logging settings if not already configured.
3. Replace the line that returns the detailed error message with a line that logs the error and returns a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
